### PR TITLE
Fix missing CSS path

### DIFF
--- a/Journal/Pathfinder World Tracker/data-management.html
+++ b/Journal/Pathfinder World Tracker/data-management.html
@@ -9,7 +9,7 @@
     <!-- Font Awesome -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="dist/css/main.min.css">
+    <link rel="stylesheet" href="styles/main.css">
     <style>
         :root {
             --bg-dark: #1a1a2e;

--- a/Journal/Pathfinder World Tracker/index.html
+++ b/Journal/Pathfinder World Tracker/index.html
@@ -9,7 +9,7 @@
     <!-- Font Awesome -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="dist/css/main.min.css">
+    <link rel="stylesheet" href="styles/main.css">
 </head>
 <body>
     <div class="container-fluid">

--- a/Journal/Pathfinder World Tracker/templates/factions.html
+++ b/Journal/Pathfinder World Tracker/templates/factions.html
@@ -9,7 +9,7 @@
     <!-- Font Awesome -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="../dist/css/main.min.css">
+    <link rel="stylesheet" href="../styles/main.css">
     <style>
         /* Ensure the app container takes full height */
         html, body, .app-container {


### PR DESCRIPTION
## Summary
- fix CSS path references to use `styles/main.css`

## Testing
- `npm test` *(fails: Cannot find module 'https://cdn.jsdelivr.net/...')*

------
https://chatgpt.com/codex/tasks/task_e_6845ee1273f4832687537b39bec6c8b5